### PR TITLE
fix: waste on CI

### DIFF
--- a/.github/workflows/cat-test-examples.yml
+++ b/.github/workflows/cat-test-examples.yml
@@ -1,10 +1,6 @@
 name: CAT
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,4 +27,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run unit tests
-        run: uv run mypy src && uv run pytest
+        run: uv run pytest
+      
+      - name: Type check Python code
+        run: uv run mypy src


### PR DESCRIPTION
do not run example on push for now
split type check