### PR TITLE
fix CI does not set number of rounds

### DIFF
--- a/.github/workflows/cat-test-examples.yml
+++ b/.github/workflows/cat-test-examples.yml
@@ -45,7 +45,7 @@ jobs:
         id: set-number-of-runs
         run: |
           [[ "${GITHUB_REF_NAME}" =~ ^ci-experiment/ ]] && ROUNDS=1 || ROUNDS=10
-          ROUNDS=${INPUT_ROUNDS:-$ROUNDS}
+          ROUNDS=${${{inputs.rounds}}:-$ROUNDS}
           
           if [ "$ROUNDS" -gt 128 ] || [ "$ROUNDS" -le 0 ]
           then

--- a/.github/workflows/cat-test-examples.yml
+++ b/.github/workflows/cat-test-examples.yml
@@ -43,9 +43,11 @@ jobs:
 
       - name: Set number of runs
         id: set-number-of-runs
+        env:
+          INPUTS_ROUNDS_OR_EMPTY: ${{ inputs.rounds }}
         run: |
           [[ "${GITHUB_REF_NAME}" =~ ^ci-experiment/ ]] && ROUNDS=1 || ROUNDS=10
-          ROUNDS=${INPUTS_ROUNDS:-$ROUNDS}
+          ROUNDS=${INPUTS_ROUNDS_OR_EMPTY:-$ROUNDS}
           
           if [ "$ROUNDS" -gt 128 ] || [ "$ROUNDS" -le 0 ]
           then

--- a/.github/workflows/cat-test-examples.yml
+++ b/.github/workflows/cat-test-examples.yml
@@ -45,7 +45,7 @@ jobs:
         id: set-number-of-runs
         run: |
           [[ "${GITHUB_REF_NAME}" =~ ^ci-experiment/ ]] && ROUNDS=1 || ROUNDS=10
-          ROUNDS=${${{inputs.rounds}}:-$ROUNDS}
+          ROUNDS=${INPUTS_ROUNDS:-$ROUNDS}
           
           if [ "$ROUNDS" -gt 128 ] || [ "$ROUNDS" -le 0 ]
           then


### PR DESCRIPTION
currently CI always runs default number of times 1 or 10. this change fixes the issue:

example of 3 rounds run:
https://github.com/thisisartium/continuous-alignment-testing/actions/runs/13804428002